### PR TITLE
Fix supportxmr.patch and Dockerfile

### DIFF
--- a/.build/supportxmr.patch
+++ b/.build/supportxmr.patch
@@ -1,8 +1,8 @@
 diff --git a/src/net/strategies/DonateStrategy.cpp b/src/net/strategies/DonateStrategy.cpp
-index b288046e..ecdea57e 100644
+index 03447a01..bf6a1eb4 100644
 --- a/src/net/strategies/DonateStrategy.cpp
 +++ b/src/net/strategies/DonateStrategy.cpp
-@@ -50,11 +50,13 @@ namespace xmrig {
+@@ -43,11 +43,13 @@ namespace xmrig {
  static inline double randomf(double min, double max)                 { return (max - min) * (((static_cast<double>(rand())) / static_cast<double>(RAND_MAX))) + min; }
  static inline uint64_t random(uint64_t base, double min, double max) { return static_cast<uint64_t>(base * randomf(min, max)); }
  
@@ -15,10 +15,10 @@ index b288046e..ecdea57e 100644
  
 +// I don't steal the donations! I redistribute most of this to the xmrig author!
 +char userName[95] = { '4','9','F','z','Q','7','C','x','F','x','L','Q','s','Y','N','H','n','G','J','8','C','N','1','B','g','J','a','B','v','r','2','F','G','P','E','i','F','V','c','b','J','7','K','s','W','D','R','z','S','x','y','N','8','S','q','4','h','H','V','S','Y','e','h','j','P','Z','L','p','G','e','2','6','c','Y','8','b','7','P','S','h','d','7','y','x','t','Z','c','r','R','j','z','6','x','d','T' };
- } /* namespace xmrig */
+ } // namespace xmrig
  
  
-@@ -77,9 +79,9 @@ xmrig::DonateStrategy::DonateStrategy(Controller *controller, IStrategyListener
+@@ -70,9 +72,9 @@ xmrig::DonateStrategy::DonateStrategy(Controller *controller, IStrategyListener
  #   endif
  
  #   ifdef XMRIG_FEATURE_TLS

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.13 AS builder
 ARG XMRIG_VERSION='v6.21.1'
 WORKDIR /miner
 
-RUN echo "@community http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
+RUN echo "@community http://dl-cdn.alpinelinux.org/alpine/v3.18/community" >> /etc/apk/repositories && \
     apk update && apk add --no-cache \
     build-base \
     git \
@@ -33,7 +33,7 @@ ENV WALLET=49FzQ7CxFxLQsYNHnGJ8CN1BgJaBvr2FGPEiFVcbJ7KsWDRzSxyN8Sq4hHVSYehjPZLpG
 ENV POOL=pool.supportxmr.com:5555
 ENV WORKER_NAME=docker
 
-RUN echo "@community http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
+RUN echo "@community http://dl-cdn.alpinelinux.org/alpine/v3.18/community" >> /etc/apk/repositories && \
     apk update && apk add --no-cache \
     libuv \
     libressl \


### PR DESCRIPTION
* The hwloc-related packages have already been removed from the edge repository, so I fixed them to v3.18.
* The patch file did not work in xmrig v6.21.1, so I fixed it.The patch file did not work in xmrig v6.21.1, so I fixed it.