### PR TITLE
Set xmrig v6.22.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.13 AS builder
 
-ARG XMRIG_VERSION='v6.21.1'
+ARG XMRIG_VERSION='v6.22.2'
 WORKDIR /miner
 
 RUN echo "@community http://dl-cdn.alpinelinux.org/alpine/v3.18/community" >> /etc/apk/repositories && \


### PR DESCRIPTION
Build test

```
[+] Building 47.0s (15/15) FINISHED                                                                                       docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                      0.0s
 => => transferring dockerfile: 1.29kB                                                                                                    0.0s
 => [internal] load metadata for docker.io/library/alpine:3.13                                                                            3.1s
 => [internal] load .dockerignore                                                                                                         0.0s
 => => transferring context: 2B                                                                                                           0.0s
 => [builder 1/7] FROM docker.io/library/alpine:3.13@sha256:469b6e04ee185740477efa44ed5bdd64a07bbdd6c7e5f5d169e540889597b911              0.0s
 => => resolve docker.io/library/alpine:3.13@sha256:469b6e04ee185740477efa44ed5bdd64a07bbdd6c7e5f5d169e540889597b911                      0.0s
 => => sha256:469b6e04ee185740477efa44ed5bdd64a07bbdd6c7e5f5d169e540889597b911 1.64kB / 1.64kB                                            0.0s
 => => sha256:448028a5480dcea5eae6ed1442fb85a44921c41972a405987883aee3abdaf410 528B / 528B                                                0.0s
 => => sha256:1384a14f8577009b729eb1ef6aabe2729ae5a35e07d4d6b84a6dd9b841a818e3 1.49kB / 1.49kB                                            0.0s
 => [internal] load build context                                                                                                         0.0s
 => => transferring context: 2.06kB                                                                                                       0.0s
 => [builder 2/7] WORKDIR /miner                                                                                                          0.0s
 => [stage-1 2/4] RUN echo "@community http://dl-cdn.alpinelinux.org/alpine/v3.18/community" >> /etc/apk/repositories &&     apk update   2.3s
 => [builder 3/7] RUN echo "@community http://dl-cdn.alpinelinux.org/alpine/v3.18/community" >> /etc/apk/repositories &&     apk update   6.8s
 => [stage-1 3/4] WORKDIR /xmr                                                                                                            0.0s
 => [builder 4/7] RUN git clone https://github.com/xmrig/xmrig &&     mkdir xmrig/build &&     cd xmrig && git checkout v6.22.2           2.0s
 => [builder 5/7] COPY .build/supportxmr.patch /miner/xmrig                                                                               0.0s
 => [builder 6/7] RUN cd xmrig && git apply supportxmr.patch                                                                              0.1s
 => [builder 7/7] RUN cd xmrig/build &&     cmake .. -DCMAKE_BUILD_TYPE=Release &&     make -j$(nproc)                                   34.8s
 => [stage-1 4/4] COPY --from=builder /miner/xmrig/build/xmrig /xmr                                                                       0.0s
 => exporting to image                                                                                                                    0.0s
 => => exporting layers                                                                                                                   0.0s
 => => writing image sha256:24874a99bc61df60122ee7975e1e9402a2117fce2cbce5d5de23ef9002e7f6dd                                              0.0s
 => => naming to docker.io/library/monero-cpu-miner                                                                                       0.0s

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/c5l1pfvenm6covcqt1avhce70
```